### PR TITLE
Added Dockerfile for dependabot-script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM dependabot/dependabot-core:0.142.0
+
+ARG CODE_DIR=/home/dependabot/dependabot-script
+RUN mkdir -p ${CODE_DIR}
+COPY --chown=dependabot:dependabot Gemfile Gemfile.lock ${CODE_DIR}/
+WORKDIR ${CODE_DIR}
+
+RUN bundle config set --local path "vendor" \
+  && bundle install --jobs 4 --retry 3
+
+COPY --chown=dependabot:dependabot . ${CODE_DIR}
+
+CMD ["bundle", "exec", "ruby", "./generic-update-script.rb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dependabot/dependabot-core:0.142.0
+FROM dependabot/dependabot-core:0.148.6
 
 ARG CODE_DIR=/home/dependabot/dependabot-script
 RUN mkdir -p ${CODE_DIR}


### PR DESCRIPTION
Added Dockerfile for dependabot-script.
We will now build an image with all the fetched dependencies, and then run this image for all repos we have.